### PR TITLE
Update yum_install.yml

### DIFF
--- a/roles/wavefront_proxy/tasks/yum_install.yml
+++ b/roles/wavefront_proxy/tasks/yum_install.yml
@@ -9,7 +9,7 @@
 
   - name: Wavefront yum repo
     template:
-      src: wavefront.repo.j2
+      src: wavefront-proxy.repo.j2
       dest: /etc/yum.repos.d/wavefront-proxy.repo
       owner: root
       group: root


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
yum_install.yml calls `src: wavefront.repo.j2` but should be `src: wavefront-proxy.repo.j2`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bug fix

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
wavefront_proxy role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Negates the need to use vmware_guest_disk_info to return backing_uuid of a newly created disk.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- block:

  - name: yum dependencies
    yum: name={{ item }} state=present
    with_items:
      - pygpgme
      - yum-utils

  - name: Wavefront yum repo
    template:
      src: wavefront-proxy.repo.j2
      dest: /etc/yum.repos.d/wavefront-proxy.repo
      owner: root
      group: root
      mode: 0644


  - name: install Wavefront Proxy
    yum: name=wavefront-proxy state=latest

  tags:
    - wavefront-proxy-repo
    - wavefront-proxy
```